### PR TITLE
Add Swagger UI (OpenAPI view) to the Gaia edition

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -77,6 +77,10 @@
             <groupId>org.eclipse.dirigible</groupId>
             <artifactId>dirigible-components-engine-bpm-flowable</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.dirigible</groupId>
+            <artifactId>dirigible-components-engine-openapi</artifactId>
+        </dependency>
 
         <!-- API -->
         <dependency>
@@ -124,6 +128,10 @@
         <dependency>
             <groupId>org.eclipse.dirigible</groupId>
             <artifactId>dirigible-components-ui-service-workspace</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.dirigible</groupId>
+            <artifactId>dirigible-components-ui-view-swagger</artifactId>
         </dependency>
 
         <!-- IDE UI -->


### PR DESCRIPTION
## Description

Enables the Swagger / OpenAPI view at `/services/web/view-swagger/ui/index.html`, which previously returned **404** in Gaia.

The `view-swagger` content component lives in the Dirigible **Web IDE group** (`dirigible-components-group-ide`), which Gaia intentionally excludes. As a result both the UI view and the spec endpoint it depends on were missing. This adds the two minimal components needed to enable Swagger without pulling in the entire IDE group.